### PR TITLE
SE-21 Added better handling for platforms on which the socket options…

### DIFF
--- a/sdk/lusid/tcp/tcp_keep_alive_probes.py
+++ b/sdk/lusid/tcp/tcp_keep_alive_probes.py
@@ -21,7 +21,9 @@ class TCPKeepAliveValidationMethods:
     @staticmethod
     def adjust_connection_socket(conn, protocol: str = "https"):
         """
-        Adjusts the socket settings so that the client sends a TCP keep alive probe over the connection.
+        Adjusts the socket settings so that the client sends a TCP keep alive probe over the connection. This is only
+        applied where possible, if the ability to set the socket options is not available, for example using Anaconda,
+        then the settings will be left as is.
 
         :param conn: The connection to update the socket settings for
         :param str protocol: The protocol of the connection
@@ -44,11 +46,11 @@ class TCPKeepAliveValidationMethods:
             pass
 
         # TCP Keep Alive Probes for Windows OS
-        elif platform == 'win32' and hasattr(socket, "SIO_KEEPALIVE_VALS"):
+        elif platform == 'win32' and hasattr(socket, "SIO_KEEPALIVE_VALS") and getattr(conn.sock, "ioctl", None) is not None:
             conn.sock.ioctl(socket.SIO_KEEPALIVE_VALS, (1, TCP_KEEP_IDLE * 1000, TCP_KEEPALIVE_INTERVAL * 1000))
 
         # TCP Keep Alive Probes for Mac OS
-        elif platform == 'darwin':
+        elif platform == 'darwin' and getattr(conn.sock, "setsockopt", None) is not None:
             conn.sock.setsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)
             conn.sock.setsockopt(socket.IPPROTO_TCP, TCP_KEEPALIVE, TCP_KEEPALIVE_INTERVAL)
 

--- a/sdk/tests/tcp/test_tcp_keep_alives.py
+++ b/sdk/tests/tcp/test_tcp_keep_alives.py
@@ -1,0 +1,39 @@
+import unittest
+
+from lusid.tcp.tcp_keep_alive_probes import TCPKeepAliveValidationMethods
+
+
+class MockSocket:
+    """
+    Mocks an SSL socket that is missing an .ioctl or .setsockopts method.
+    """
+    def __init__(self):
+        """
+        No need to initialise anything here as it is an empty class which is missing
+        a .ioctl and .setsockopts method
+        """
+        pass
+
+
+class MockConnection:
+    """
+    Mocks a connection with an SSL socket
+    """
+    def __init__(self, sock):
+        """
+        :param sock: The socket to use with the connection
+        """
+        self.sock = sock
+
+
+class TestTCPKeepAlives(unittest.TestCase):
+
+    def test_wrapped_socket_no_attributes_does_not_throw(self):
+        """
+        Tests that if the provided socket is missing the function required to set the socket options,
+        the socket options are left as is, rather than an AttributeError being raised
+
+        :return: None
+        """
+
+        TCPKeepAliveValidationMethods.adjust_connection_socket(MockConnection(sock=MockSocket()))


### PR DESCRIPTION
… can either not be set, or we do not know how to set them yet. Previously these platforms would be completely unable to use the SDK due to the raising of an AttributeError. The new behaviour is to leave the socket settings unchanged on these platforms

# Pull Request Checklist

- [x ] Read the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x ] Tests pass
- [x ] Raised the PR against the `develop` branch

# Description of the PR

Describe the code changes for the reviewers, explain the solution you have provided and how it fixes the issue
