### PR TITLE
WIP SE-94 Cache tokens

### DIFF
--- a/sdk/lusid/utilities/__init__.py
+++ b/sdk/lusid/utilities/__init__.py
@@ -5,3 +5,4 @@ from lusid.utilities.api_client_factory import ApiClientFactory
 from lusid.utilities.lusid_retry import lusidretry
 from lusid.utilities.proxy_config import ProxyConfig
 from lusid.utilities.api_configuration import ApiConfiguration
+from lusid.utilities.client_credentials_flow_provider import ClientCredentialsFlowProvider

--- a/sdk/lusid/utilities/client_credentials_flow_provider.py
+++ b/sdk/lusid/utilities/client_credentials_flow_provider.py
@@ -1,0 +1,70 @@
+from urllib.request import pathname2url
+
+import requests
+
+from .refreshing_token import RefreshingToken
+
+
+class ClientCredentialsFlowProvider:
+
+    def __init__(self, configuration, okta_response_handler):
+        """
+        :param ApiConfiguration configuration: The configuration to use
+        :param typing.callable okta_response_handler: An optional function to handle the Okta response
+        """
+        self.configuration = configuration
+        self.okta_response_handler = okta_response_handler
+
+    def get_auth_token(self):
+        """
+        Get an authentication token
+
+        :return: RefreshingToken api_token: A refreshing API token
+        """
+
+        # Encode credentials that may contain special characters
+        encoded_password = pathname2url(self.configuration.password)
+        encoded_client_id = pathname2url(self.configuration.client_id)
+        encoded_client_secret = pathname2url(self.configuration.client_secret)
+
+        # Prepare our authentication request
+        token_request_body = f"grant_type=password&username={self.configuration.username}" \
+                             f"&password={encoded_password}&scope=openid client groups offline_access" \
+                             f"&client_id={encoded_client_id}&client_secret={encoded_client_secret}"
+
+        headers = {"Accept": "application/json", "Content-Type": "application/x-www-form-urlencoded"}
+
+        # extra request args
+        kwargs = {"headers": headers}
+
+        if self.configuration.proxy_config is not None:
+            kwargs["proxies"] = self.configuration.proxy_config.format_proxy_schema()
+
+        # use certificate if supplied
+        if self.configuration.certificate_filename is not None:
+            kwargs["verify"] = self.configuration.certificate_filename
+
+        # make request to Okta to get an authentication token
+        okta_response = requests.post(self.configuration.token_url, data=token_request_body, **kwargs)
+
+        if self.okta_response_handler is not None:
+            self.okta_response_handler(okta_response)
+
+        # Ensure that we have a 200 response code
+        if okta_response.status_code != 200:
+            raise ValueError(okta_response.json())
+
+        # convert the json encoded response to be able to extract the token values
+        okta_json = okta_response.json()
+
+        # Retrieve our api token from the authentication response
+        api_token = RefreshingToken(token_url=self.configuration.token_url,
+                                    client_id=encoded_client_id,
+                                    client_secret=encoded_client_secret,
+                                    initial_access_token=okta_json["access_token"],
+                                    initial_token_expiry=okta_json["expires_in"],
+                                    refresh_token=okta_json["refresh_token"],
+                                    proxies=kwargs.get("proxies", None),
+                                    certificate_filename=kwargs.get("verify", None))
+
+        return api_token

--- a/sdk/lusid/utilities/refreshing_token.py
+++ b/sdk/lusid/utilities/refreshing_token.py
@@ -44,9 +44,11 @@ class RefreshingToken(UserString):
                 request_body = f"grant_type=refresh_token&scope=openid client groups offline_access&refresh_token={refresh_token}"
 
                 # request parameters
-                kwargs = {"headers": headers}
-                kwargs["proxies"] = proxies
-                kwargs["verify"] = certificate_filename
+                kwargs = {
+                    "headers": headers,
+                    "proxies": proxies,
+                    "verify": certificate_filename
+                }
 
                 okta_response = requests.post(token_url, data=request_body, **kwargs)
 

--- a/sdk/requirements.dev.txt
+++ b/sdk/requirements.dev.txt
@@ -1,1 +1,3 @@
+-r requirements.txt
+asynctest
 parameterized==0.7.*

--- a/sdk/tests/utilities/test_api_client_builder.py
+++ b/sdk/tests/utilities/test_api_client_builder.py
@@ -74,6 +74,7 @@ class ApiClientBuilderTests(unittest.TestCase):
         api_configuration = ApiConfiguration(**{
                     key: value for key, value in source_config_details.items() if "proxy" not in key
         })
+        api_configuration.app_name = "test_build_client_no_token_provided_config_takes_precedence"
 
         # Use a temporary file and no environment variables to generate the API Client
         with patch.dict('os.environ', env_vars, clear=True), patch("requests.post") as mock_requests:
@@ -107,6 +108,7 @@ class ApiClientBuilderTests(unittest.TestCase):
                         value is not None and "proxy" not in key
                     }
                 }
+        secrets["api"]["applicationName"] = "test_build_client_no_token_provided_file_only"
 
         env_vars = {}
 
@@ -163,6 +165,7 @@ class ApiClientBuilderTests(unittest.TestCase):
                 value is not None and "proxy" not in key
             }
         }
+        secrets["api"]["applicationName"] = "test_build_client_with_token_provided"
 
         [secrets.pop(config) for config in config_to_remove]
 
@@ -186,6 +189,7 @@ class ApiClientBuilderTests(unittest.TestCase):
         api_configuration = ApiConfiguration(**{
             key: value for key, value in source_config_details.items() if "proxy" not in key
         })
+        api_configuration.app_name = "test_use_okta_response_handler"
 
         api_configuration.certificate_filename = None
 

--- a/sdk/tests/utilities/test_token.py
+++ b/sdk/tests/utilities/test_token.py
@@ -1,0 +1,39 @@
+import asyncio
+import functools
+
+import asynctest
+from functools import wraps, partial
+
+from lusid.utilities import ApiClientFactory
+from utilities import CredentialsSource
+
+
+def run_async(func):
+
+    @wraps(func)
+    async def run(*args, loop=None, executor=None, **kwargs):
+        if loop is None:
+            loop = asyncio.get_event_loop()
+        pfunc = partial(func, *args, **kwargs)
+        return await loop.run_in_executor(executor, pfunc)
+
+    return run
+
+
+class TokenTests(asynctest.TestCase):
+
+    @run_async
+    def build_factory(self):
+        factory = ApiClientFactory(
+            api_secrets_filename=CredentialsSource.secrets_path()
+        )
+        return factory.api_client.configuration.access_token
+
+    async def get_all_tokens(self):
+        result = await asyncio.gather(*[self.build_factory() for _ in range(0, 5)], return_exceptions=True)
+        return result
+
+    async def test_get_concurrent_tokens(self):
+        tokens = await self.get_all_tokens()
+
+        self.assertEqual(1, len(set(tokens)), "tokens not all equal")

--- a/sdk/tests/utilities/test_token_refresh.py
+++ b/sdk/tests/utilities/test_token_refresh.py
@@ -67,14 +67,13 @@ class TokenRefresh(unittest.TestCase):
             proxy_url = os.getenv("HTTPS_PROXY", None)
 
         if proxy_url is not None:
-
             refreshed_token = RefreshingToken(token_url=self.config.token_url,
                                               client_id=self.config.client_id,
                                               client_secret=self.config.client_secret,
                                               initial_access_token=original_token,
                                               initial_token_expiry=1,  # 1s expiry
                                               refresh_token=refresh_token,
-                                              expiry_offset=3599,     # set to 1s expiry
+                                              expiry_offset=3599,  # set to 1s expiry
                                               proxies={})
 
             self.assertIsNotNone(refreshed_token)
@@ -115,11 +114,10 @@ class TokenRefresh(unittest.TestCase):
                                           initial_access_token=original_token,
                                           initial_token_expiry=1,  # 1s expiry
                                           refresh_token=refresh_token,
-                                          expiry_offset=3599,     # set to 1s expiry
+                                          expiry_offset=3599,  # set to 1s expiry
                                           proxies=proxies)
 
         self.assertIsNotNone(refreshed_token)
-
 
     def test_refreshed_token_when_expired(self):
         original_token, refresh_token = tu.get_okta_tokens(CredentialsSource.secrets_path())


### PR DESCRIPTION
# Pull Request Checklist

- [x] Read the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] Tests pass
- [x] Raised the PR against the `develop` branch

# Description of the PR

If ApiFactories are created on multiple threads it is possible to get rate limited by Okta. This PR caches tokens for the same set of credentials to avoid making unnecessary calls to Okta
