### PR TITLE
SE-857 Moved the creation of the first access token into the refresh …

### DIFF
--- a/sdk/lusid/utilities/api_client_builder.py
+++ b/sdk/lusid/utilities/api_client_builder.py
@@ -1,7 +1,5 @@
 from urllib3 import make_headers
-from urllib.request import pathname2url
 import os
-import requests
 
 from lusid import Configuration, ApiClient
 
@@ -37,68 +35,11 @@ class ApiClientBuilder:
                 f"please ensure that you have provided them directly, via a secrets file or environment "
                 f"variables")
 
-    @staticmethod
-    def __generate_access_token(configuration, okta_response_handler):
-        """
-        This function generates an access token by making a call to Okta
-
-        :param ApiConfiguration configuration: The configuration to use
-        :param typing.callable okta_response_handler: An optional function to handle the Okta response
-
-        :return: RefreshingToken api_token: A refreshing API token
-        """
-        # Encode credentials that may contain special characters
-        encoded_password = pathname2url(configuration.password)
-        encoded_client_id = pathname2url(configuration.client_id)
-        encoded_client_secret = pathname2url(configuration.client_secret)
-
-        # Prepare our authentication request
-        token_request_body = f"grant_type=password&username={configuration.username}" \
-            f"&password={encoded_password}&scope=openid client groups offline_access" \
-            f"&client_id={encoded_client_id}&client_secret={encoded_client_secret}"
-
-        headers = {"Accept": "application/json", "Content-Type": "application/x-www-form-urlencoded"}
-
-        # extra request args
-        kwargs = {"headers": headers}
-
-        if configuration.proxy_config is not None:
-            kwargs["proxies"] = configuration.proxy_config.format_proxy_schema()
-
-        # use certificate if supplied
-        if configuration.certificate_filename is not None:
-            kwargs["verify"] = configuration.certificate_filename
-
-        # make request to Okta to get an authentication token
-        okta_response = requests.post(configuration.token_url, data=token_request_body, **kwargs)
-
-        if okta_response_handler is not None:
-            okta_response_handler(okta_response)
-
-        # Ensure that we have a 200 response code
-        if okta_response.status_code != 200:
-            raise ValueError(okta_response.json())
-
-        # convert the json encoded response to be able to extract the token values
-        okta_json = okta_response.json()
-
-        # Retrieve our api token from the authentication response
-        api_token = RefreshingToken(token_url=configuration.token_url,
-                                    client_id=encoded_client_id,
-                                    client_secret=encoded_client_secret,
-                                    initial_access_token=okta_json["access_token"],
-                                    initial_token_expiry=okta_json["expires_in"],
-                                    refresh_token=okta_json["refresh_token"],
-                                    proxies=kwargs.get("proxies", None),
-                                    certificate_filename=kwargs.get("verify", None))
-
-        return api_token
-
     @classmethod
-    def build(cls, api_secrets_filename=None, okta_response_handler=None, api_configuration=None, token=None, correlation_id=None):
+    def build(cls, api_secrets_filename=None, id_provider_response_handler=None, api_configuration=None, token=None, correlation_id=None):
         """
         :param str api_secrets_filename: The full path to the JSON file containing the API credentials and optional proxy details
-        :param typing.callable okta_response_handler: An optional function to handle the Okta response
+        :param typing.callable id_provider_response_handler: An optional function to handle the Okta response
         :param lusid.utilities.ApiConfiguration api_configuration: A pre-populated ApiConfiguration
         :param str token: The pre-populated access token to use instead of asking Okta for a token
         :param str correlation_id: Correlation id for all calls made from the returned ApiClient instance, added as a header to each request
@@ -132,9 +73,9 @@ class ApiClientBuilder:
                 "token_url"])
 
             # Generate an access token
-            api_token = cls.__generate_access_token(
-                configuration=configuration,
-                okta_response_handler=okta_response_handler
+            api_token = RefreshingToken(
+                api_configuration=configuration,
+                id_provider_response_handler=id_provider_response_handler
             )
 
         # Initialise the API client using the token so that it can be included in all future requests

--- a/sdk/lusid/utilities/refreshing_token.py
+++ b/sdk/lusid/utilities/refreshing_token.py
@@ -4,72 +4,144 @@ import base64
 from datetime import datetime
 from datetime import timedelta
 from collections import UserString
+from urllib.request import pathname2url
 
 
 class RefreshingToken(UserString):
 
-    def __init__(self, token_url, client_id, client_secret, initial_access_token, initial_token_expiry, refresh_token,
-                 expiry_offset=60, proxies=None, certificate_filename=None):
+    def __init__(self, api_configuration, expiry_offset=60, id_provider_response_handler=None):
         """
         Implementation of UserString that will automatically refresh the token value upon expiry
 
-        :param str token_url: token refresh url
-        :param str client_id: OpenID Connect Client ID
-        :param str client_secret: OpenID Connect Client Secret
-        :param str initial_access_token: initial access token
-        :param int initial_token_expiry: number of seconds the initial token is valid for before expiring
-        :param str refresh_token: initial refresh token
+        :param ApiConfiguration api_configuration: The api configuration with all required values
         :param int expiry_offset: number of seconds before token expiry to refresh the token
-        :param dict proxies: dictionary containing proxy schemas
-        :param str certifiate_filename: The path to the client side certificate to use
         """
 
-        token_data = {
-            "expires": datetime.utcnow() + timedelta(seconds=initial_token_expiry),
-            "access_token": initial_access_token
+        self.token_data = {
+            "expires": None,
+            "access_token": None,
+            "refresh_token": None
         }
+        self.expiry_offset = expiry_offset
+        self.api_configuration = api_configuration
+        self.id_provider_response_handler = id_provider_response_handler
+        self.refresh_func = self.get_refresh_token
 
-        def get_refresh_token():
+    def update_token_data(self, id_provider_json):
+        """
+        Updates the token data from a response from the identity provider
 
-            # check if the token has expired and refresh if needed
-            if token_data["expires"] <= datetime.utcnow():
+        :param id_provider_json: The JSON to use to update the token data
+        """
+        self.token_data["access_token"] = id_provider_json["access_token"]
+        # Set the expiry just before the actual expiry to ensure no failed requests
+        delta = timedelta(seconds=id_provider_json.get("expires_in", 3600) - self.expiry_offset)
+        self.token_data["expires"] = datetime.utcnow() + delta
+        self.token_data["refresh_token"] = id_provider_json["refresh_token"]
 
-                encoded_client = base64.b64encode(bytes(f"{client_id}:{client_secret}", 'utf-8'))
+    def get_access_token(self):
+        """
+        Retrieves an access token from the identity provider using the credentials in the provided configuration
 
-                headers = {
-                    "Content-Type": "application/x-www-form-urlencoded",
-                    "Authorization": f"Basic {encoded_client.decode('utf-8')}"
-                }
+        :return: The retrieved access token
+        """
 
-                request_body = f"grant_type=refresh_token&scope=openid client groups offline_access&refresh_token={refresh_token}"
+        encoded_password = pathname2url(self.api_configuration.password)
+        encoded_client_id = pathname2url(self.api_configuration.client_id)
+        encoded_client_secret = pathname2url(self.api_configuration.client_secret)
 
-                # request parameters
-                kwargs = {"headers": headers}
-                kwargs["proxies"] = proxies
-                kwargs["verify"] = certificate_filename
+        # Prepare our authentication request
+        token_request_body = f"grant_type=password&username={self.api_configuration.username}" \
+            f"&password={encoded_password}&scope=openid client groups offline_access" \
+            f"&client_id={encoded_client_id}&client_secret={encoded_client_secret}"
 
-                okta_response = requests.post(token_url, data=request_body, **kwargs)
+        headers = {"Accept": "application/json", "Content-Type": "application/x-www-form-urlencoded"}
 
-                if okta_response.status_code != 200:
-                    raise Exception(okta_response.json())
+        # extra request args
+        kwargs = {"headers": headers}
 
-                okta_json = okta_response.json()
+        if self.api_configuration.proxy_config is not None:
+            kwargs["proxies"] = self.api_configuration.proxy_config.format_proxy_schema()
 
-                # set the expiry just before the actual expiry to be able to refresh in time
-                delta = timedelta(seconds=okta_json.get("expires_in", 3600) - expiry_offset)
-                token_data["expires"] = datetime.utcnow() + delta
-                token_data["access_token"] = okta_json["access_token"]
+        # use certificate if supplied
+        if self.api_configuration.certificate_filename is not None:
+            kwargs["verify"] = self.api_configuration.certificate_filename
 
-            return token_data["access_token"]
+        # make request to Okta to get an authentication token
+        id_provider_response = requests.post(self.api_configuration.token_url, data=token_request_body, **kwargs)
 
-        self.refresh_func = get_refresh_token
+        if self.id_provider_response_handler is not None:
+            self.id_provider_response_handler(id_provider_response)
+
+        # Ensure that we have a 200 response code
+        if id_provider_response.status_code != 200:
+            raise ValueError(id_provider_response.json())
+
+        # convert the json encoded response to be able to extract the token values
+        id_provider_json = id_provider_response.json()
+
+        self.update_token_data(id_provider_json)
+
+        return self.token_data["access_token"]
+
+    def get_refresh_token(self):
+        """
+        Retrieves an access token from the identity provider using the refresh token
+
+        :return: The retrieved access token
+        """
+
+        # If any data is missing to use a refresh token e.g. on first try, get an access token using credentials
+        if self.token_data["access_token"] is None or self.token_data["expires"] is None or self.token_data["refresh_token"] is None:
+            return self.get_access_token()
+
+        # check if the token has expired and refresh if needed
+        if self.token_data["expires"] <= datetime.utcnow():
+
+            encoded_client = base64.b64encode(bytes(f"{self.api_configuration.client_id}:{self.api_configuration.client_secret}", 'utf-8'))
+
+            headers = {
+                "Content-Type": "application/x-www-form-urlencoded",
+                "Authorization": f"Basic {encoded_client.decode('utf-8')}"
+            }
+
+            request_body = f"grant_type=refresh_token&scope=openid client groups offline_access&refresh_token={self.token_data['refresh_token']}"
+
+            # request parameters
+            kwargs = {"headers": headers}
+
+            if self.api_configuration.proxy_config is not None:
+                kwargs["proxies"] = self.api_configuration.proxy_config.format_proxy_schema()
+
+            if self.api_configuration.certificate_filename is not None:
+                kwargs["verify"] = self.api_configuration.certificate_filename
+
+            id_provider_response = requests.post(self.api_configuration.token_url, data=request_body, **kwargs)
+
+            # Refresh token may be expired, if so, get new request token
+            if id_provider_response.status_code == 400 and 'refresh token is invalid or expired' \
+                    in id_provider_response.json()['error_description']:
+                return self.get_access_token()
+            elif id_provider_response.status_code != 200:
+                raise ValueError(id_provider_response.json())
+
+            id_provider_json = id_provider_response.json()
+
+            self.update_token_data(id_provider_json)
+
+        return self.token_data["access_token"]
 
     def __getattribute__(self, item):
 
-        token = object.__getattribute__(self, "refresh_func")()
-
         # return the value of the string
         if item == "data":
-            return token
+            return object.__getattribute__(self, "refresh_func")()
 
-        return token.__getattribute__(item)
+        # get the attribute on the string value, not the RefreshingToken class itself, used for UserString base methods
+        # such as string concatenation, if this is missing the whole RefreshingToken class gets created again with the
+        # concatenated string as the input
+        if item == "__class__":
+            return object.__getattribute__(self, "refresh_func")().__getattribute__(item)
+
+        # used to get .self attributes on the RefreshingToken
+        return object.__getattribute__(self, item)

--- a/sdk/tests/utilities/test_api_client_builder.py
+++ b/sdk/tests/utilities/test_api_client_builder.py
@@ -92,9 +92,9 @@ class ApiClientBuilderTests(unittest.TestCase):
                 api_configuration=api_configuration)
 
             TempFileManager.delete_temp_file(secrets_file)
+            self.assertEqual(client.configuration.access_token, "mock_access_token")
 
         self.assertEqual(client.configuration.host, source_config_details["api_url"])
-        self.assertEqual(client.configuration.access_token, "mock_access_token")
         self.assertIsInstance(client, ApiClient)
 
     def test_build_client_no_token_provided_file_only(self):
@@ -128,9 +128,9 @@ class ApiClientBuilderTests(unittest.TestCase):
                 api_configuration=api_configuration)
 
             TempFileManager.delete_temp_file(secrets_file)
+            self.assertEqual(client.configuration.access_token, "mock_access_token")
 
         self.assertEqual(client.configuration.host, source_config_details["api_url"])
-        self.assertEqual(client.configuration.access_token, "mock_access_token")
         self.assertIsInstance(client, ApiClient)
 
     @parameterized.expand(
@@ -201,9 +201,12 @@ class ApiClientBuilderTests(unittest.TestCase):
                 "expires_in": 60
             }
 
-            ApiClientBuilder.build(
+            client = ApiClientBuilder.build(
                 api_configuration=api_configuration,
-                okta_response_handler=response_handler)
+                id_provider_response_handler=response_handler)
+
+            # Force evaluation of the access token so that it is retrieved
+            repr(client.configuration.access_token)
 
     def test_set_correlation_id_from_env_var(self):
 

--- a/sdk/tests/utilities/test_token_refresh.py
+++ b/sdk/tests/utilities/test_token_refresh.py
@@ -8,7 +8,6 @@ from lusid.utilities import RefreshingToken
 
 from utilities import CredentialsSource
 from unittest.mock import patch
-from utilities import TokenUtilities as tu
 from utilities.temp_file_manager import TempFileManager
 
 source_config_details, config_keys = CredentialsSource.fetch_credentials(), CredentialsSource.fetch_config_keys()
@@ -16,22 +15,24 @@ source_config_details, config_keys = CredentialsSource.fetch_credentials(), Cred
 
 class TokenRefresh(unittest.TestCase):
 
+    class MockApiResponse:
+
+        def __init__(self, json_data, status_code):
+            self.json_data = json_data
+            self.status_code = status_code
+
+        def json(self):
+            return self.json_data
+
+
     @classmethod
     def setUpClass(cls):
         cls.config = ApiConfigurationLoader.load(CredentialsSource.secrets_path())
 
     def test_get_token(self):
-        original_token, refresh_token = tu.get_okta_tokens(CredentialsSource.secrets_path())
 
-        refreshed_token = RefreshingToken(token_url=self.config.token_url,
-                                          client_id=self.config.client_id,
-                                          client_secret=self.config.client_secret,
-                                          initial_access_token=original_token,
-                                          initial_token_expiry=3600,
-                                          refresh_token=refresh_token)
-
+        refreshed_token = RefreshingToken(api_configuration=self.config)
         self.assertIsNotNone(refreshed_token)
-        self.assertEqual(original_token, refreshed_token)
 
     def test_get_token_with_proxy(self):
 
@@ -51,9 +52,7 @@ class TokenRefresh(unittest.TestCase):
         if secrets["proxy"].get("address", None) is None:
             self.skipTest(f"missing proxy configuration")
 
-        secrets_file = TempFileManager.create_temp_file(secrets)
-
-        original_token, refresh_token = tu.get_okta_tokens(secrets_file.name)
+        TempFileManager.create_temp_file(secrets)
 
         proxy_config = ProxyConfig(
             address=secrets["proxy"]["address"],
@@ -68,14 +67,8 @@ class TokenRefresh(unittest.TestCase):
 
         if proxy_url is not None:
 
-            refreshed_token = RefreshingToken(token_url=self.config.token_url,
-                                              client_id=self.config.client_id,
-                                              client_secret=self.config.client_secret,
-                                              initial_access_token=original_token,
-                                              initial_token_expiry=1,  # 1s expiry
-                                              refresh_token=refresh_token,
-                                              expiry_offset=3599,     # set to 1s expiry
-                                              proxies={})
+            refreshed_token = RefreshingToken(api_configuration=self.config,
+                                              expiry_offset=3599)
 
             self.assertIsNotNone(refreshed_token)
 
@@ -97,39 +90,16 @@ class TokenRefresh(unittest.TestCase):
         if secrets["proxy"].get("address", None) is None:
             self.skipTest(f"missing proxy configuration")
 
-        secrets_file = TempFileManager.create_temp_file(secrets)
+        TempFileManager.create_temp_file(secrets)
 
-        original_token, refresh_token = tu.get_okta_tokens(secrets_file.name)
-
-        proxy_config = ProxyConfig(
-            address=secrets["proxy"]["address"],
-            username=secrets["proxy"]["username"],
-            password=secrets["proxy"]["password"]
-        )
-
-        proxies = proxy_config.format_proxy_schema()
-
-        refreshed_token = RefreshingToken(token_url=self.config.token_url,
-                                          client_id=self.config.client_id,
-                                          client_secret=self.config.client_secret,
-                                          initial_access_token=original_token,
-                                          initial_token_expiry=1,  # 1s expiry
-                                          refresh_token=refresh_token,
-                                          expiry_offset=3599,     # set to 1s expiry
-                                          proxies=proxies)
+        refreshed_token = RefreshingToken(api_configuration=self.config,
+                                          expiry_offset=3599)
 
         self.assertIsNotNone(refreshed_token)
 
-
     def test_refreshed_token_when_expired(self):
-        original_token, refresh_token = tu.get_okta_tokens(CredentialsSource.secrets_path())
 
-        refreshed_token = RefreshingToken(token_url=self.config.token_url,
-                                          client_id=self.config.client_id,
-                                          client_secret=self.config.client_secret,
-                                          initial_access_token=original_token,
-                                          initial_token_expiry=1,  # 1s expiry
-                                          refresh_token=refresh_token,
+        refreshed_token = RefreshingToken(api_configuration=self.config,
                                           expiry_offset=3599)  # set to 1s expiry
 
         self.assertIsNotNone(refreshed_token)
@@ -141,15 +111,40 @@ class TokenRefresh(unittest.TestCase):
 
         self.assertNotEqual(first_value, refreshed_token)
 
-    def test_token_when_not_expired_does_not_refresh(self):
-        original_token, refresh_token = tu.get_okta_tokens(CredentialsSource.secrets_path())
+    def test_token_when_refresh_token_expired_still_refreshes(self):
 
-        refreshed_token = RefreshingToken(token_url=self.config.token_url,
-                                          client_id=self.config.client_id,
-                                          client_secret=self.config.client_secret,
-                                          initial_access_token=original_token,
-                                          initial_token_expiry=3600,
-                                          refresh_token=refresh_token)
+        refreshed_token = RefreshingToken(api_configuration=self.config, expiry_offset=3599)
+
+        self.assertIsNotNone(refreshed_token)
+
+        # force de-referencing the token value
+        first_value = f"{refreshed_token}"
+
+        sleep(1)
+
+        with patch("requests.post", side_effect=[
+            self.MockApiResponse(
+                json_data={
+                    "error": "invalid_grant",
+                    "error_description": "The refresh token is invalid or expired."
+                },
+                status_code=400
+            ),
+            self.MockApiResponse(
+                json_data={
+                    "access_token": "mock_access_token",
+                    "refresh_token": "mock_refresh_token",
+                    "expires_in": 60
+                },
+                status_code=200
+            ),
+        ]):
+
+            self.assertNotEqual(first_value, refreshed_token)
+
+    def test_token_when_not_expired_does_not_refresh(self):
+
+        refreshed_token = RefreshingToken(api_configuration=self.config)
 
         self.assertIsNotNone(refreshed_token)
 
@@ -161,14 +156,8 @@ class TokenRefresh(unittest.TestCase):
         self.assertEqual(first_value, refreshed_token)
 
     def test_can_make_header(self):
-        original_token, refresh_token = tu.get_okta_tokens(CredentialsSource.secrets_path())
 
-        refreshed_token = RefreshingToken(token_url=self.config.token_url,
-                                          client_id=self.config.client_id,
-                                          client_secret=self.config.client_secret,
-                                          initial_access_token=original_token,
-                                          initial_token_expiry=3600,
-                                          refresh_token=refresh_token)
+        refreshed_token = RefreshingToken(api_configuration=self.config)
 
         header = "Bearer " + refreshed_token
 

--- a/sdk/tests/utilities/token_utilities.py
+++ b/sdk/tests/utilities/token_utilities.py
@@ -16,6 +16,7 @@ class TokenUtilities:
             refresh_token = okta_json["refresh_token"]
             original_token = okta_json["access_token"]
 
-        ApiClientBuilder().build(secrets_path, extract_refresh_token)
+        client = ApiClientBuilder().build(secrets_path, extract_refresh_token)
+        repr(client.configuration.access_token)
 
         return original_token, refresh_token


### PR DESCRIPTION
…token's logic so that it is able to get a new access token in the instance that a refresh token expired. Also noticed that the refresh token was using the same refresh token over its entire life instead of updating the refresh token on each refresh of the access token. This has also been resolved

# Pull Request Checklist

- [x ] Read the [contributing guidelines](../docs/CONTRIBUTING.md)
- [ ] Tests pass
- [x ] Raised the PR against the `develop` branch

# Description of the PR

Describe the code changes for the reviewers, explain the solution you have provided and how it fixes the issue
