### PR TITLE
DEV-11069: remove orderbookid from tests.

### DIFF
--- a/sdk/tests/tutorials/ibor/test_orders.py
+++ b/sdk/tests/tutorials/ibor/test_orders.py
@@ -70,13 +70,11 @@ class Orders(unittest.TestCase):
                       f"Order/{orders_scope}/Strategy":
                           PerpetualProperty(f"Order/{orders_scope}/Strategy", PropertyValue("RiskArb"))}
 
-        order_book_id = ResourceId(orders_scope, "OrdersTestBook")
         quantity = 100
         # Construct request
         order_request = OrderRequest(properties=properties,
                                      instrument_identifiers=instrument_identifiers,
                                      quantity=quantity, side='buy',
-                                     order_book_id=order_book_id,
                                      portfolio_id=portfolio_id, id=order_resource_id)
 
         order_set_request = OrderSetRequest(order_requests=[order_request])


### PR DESCRIPTION
# Pull Request Checklist

- [X] Read the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] Tests pass
- [X] Raised the PR against the `develop` branch

# Description of the PR

`Order.OrderBookId` has recently been made optional. Ultimately, we'll remove it. In this PR, I remove it from SDK tests to demonstrate that it's optional, and to raise a flag if someone makes it a required field again.
