### PR TITLE
Feature/se 1381.add access token env var support

### DIFF
--- a/sdk/docker-compose.yml
+++ b/sdk/docker-compose.yml
@@ -28,6 +28,7 @@ services:
       - FBN_PROXY_ADDRESS=http://tinyproxy:8888
       - FBN_PROXY_USERNAME=user
       - FBN_PROXY_PASSWORD=password
+      - FBN_LUSID_ACCESS_TOKEN
     volumes:
       - .:/usr/src
     depends_on:

--- a/sdk/lusid/utilities/api_client_builder.py
+++ b/sdk/lusid/utilities/api_client_builder.py
@@ -52,6 +52,11 @@ class ApiClientBuilder:
         # Load the configuration
         configuration = ApiConfigurationLoader.load(api_secrets_filename)
 
+        # If token is passed in by user, use that pat
+        # Otherwise use the attribute set on the ApiConfigurationLoader
+        if token is not None:
+            configuration.access_token = token
+
         # If an api_configuration has been provided override the loaded configuration with any properties that it has
         if api_configuration is not None:
             for key, value in vars(api_configuration).items():
@@ -59,10 +64,11 @@ class ApiClientBuilder:
                     setattr(configuration, key, value)
 
         # Use the access token provided if it exists
-        if token is not None:
+        if configuration.access_token is not None:
             # Check that there is an api_url available
             cls.__check_required_fields(configuration, ["api_url"])
-            api_token = token
+            api_token = configuration.access_token
+
         # Otherwise generate an access token from Okta and use a RefreshingToken going forward
         else:
             # Check that all the required fields for generating a token exist

--- a/sdk/lusid/utilities/api_client_builder.py
+++ b/sdk/lusid/utilities/api_client_builder.py
@@ -36,7 +36,8 @@ class ApiClientBuilder:
                 f"variables")
 
     @classmethod
-    def resolve_api_token(cls, token, configuration, id_provider_response_handler):
+    def resolve_api_token(cls, token=None, api_secrets_filename=None, configuration=None,
+                          id_provider_response_handler=None):
 
         """
         Description:
@@ -51,9 +52,10 @@ class ApiClientBuilder:
         PAT are used in preference to supplied credentials.
         secrets files are used in preference to environment variables.
 
-        :param ApiConfiguration configuration:
-        :param str token:
-        :param ApiConfiguration configuration:
+        :param str token: The pre-populated access token to use instead of asking Okta for a token
+        :param str api_secrets_filename: The full path to the JSON file containing the API credentials and optional proxy details
+        :param ApiConfiguration configuration: configuration object containing secrets loaded from env vars
+        :param typing.callable id_provider_response_handler: An optional function to handle the Okta response
 
         :return: str api_token
         """
@@ -112,7 +114,7 @@ class ApiClientBuilder:
                 if value is not None:
                     setattr(configuration, key, value)
 
-        api_token = cls.resolve_api_token(token, configuration, id_provider_response_handler)
+        api_token = cls.resolve_api_token(token, api_secrets_filename, configuration, id_provider_response_handler)
 
         # Initialise the API client using the token so that it can be included in all future requests
         config = Configuration(tcp_keep_alive=tcp_keep_alive)

--- a/sdk/lusid/utilities/api_client_builder.py
+++ b/sdk/lusid/utilities/api_client_builder.py
@@ -63,7 +63,7 @@ class ApiClientBuilder:
 
             """
             Description:
-            This method uses a token or secrets to build an API client.
+            This method uses a PAT (Personal Access Token) or secrets to return an API token.
             The method uses the following conditional logic in order of precedence to resolve an
             authentication path:
 

--- a/sdk/lusid/utilities/api_client_factory.py
+++ b/sdk/lusid/utilities/api_client_factory.py
@@ -35,6 +35,7 @@ class ApiClientFactory:
         builder_kwargs = {}
 
         if "token" in kwargs and str(kwargs["token"]) != "None":
+
             # If there is a token use it along with the specified proxy details if specified
             config = ApiConfiguration(
                 api_url=kwargs.get("api_url", None),

--- a/sdk/lusid/utilities/api_configuration.py
+++ b/sdk/lusid/utilities/api_configuration.py
@@ -4,7 +4,7 @@ import re
 class ApiConfiguration:
 
     def __init__(self, token_url=None, api_url=None, username=None, password=None, client_id=None, client_secret=None,
-                 app_name=None, certificate_filename=None, proxy_config=None):
+                 app_name=None, certificate_filename=None, proxy_config=None, access_token=None):
         """
         The configuration required to access LUSID, read more at https://support.finbourne.com/getting-started-with-apis-sdks
 
@@ -27,6 +27,7 @@ class ApiConfiguration:
         self.__app_name = app_name
         self.__certificate_filename = certificate_filename
         self.__proxy_config = proxy_config
+        self.__access_token = access_token
 
     @property
     def token_url(self):
@@ -114,3 +115,12 @@ class ApiConfiguration:
     @proxy_config.setter
     def proxy_config(self, value):
         self.__proxy_config = value
+
+    @property
+    def access_token(self):
+        return self.__access_token
+
+    @access_token.setter
+    def access_token(self, value):
+        self.__access_token = value
+

--- a/sdk/lusid/utilities/api_configuration_loader.py
+++ b/sdk/lusid/utilities/api_configuration_loader.py
@@ -19,6 +19,7 @@ class ApiConfigurationLoader:
 
         :return: lusid.utilities.ApiConfiguration: The populated ApiConfiguration
         """
+
         # Get the config keys which contain the mapping between the ApiConfiguration attributes and the variable names
         # in the secrets.json file and environment variables e.g. token_url is tokenUrl (secrets.json) and
         # FBN_TOKEN_URL (env variable)
@@ -29,32 +30,52 @@ class ApiConfigurationLoader:
         api_config_key = "api"
         proxy_config_key = "proxy"
 
-        # If there is a secrets file specified and it exists get the details from it
-        if api_secrets_filename is not None and os.path.exists(api_secrets_filename) and os.path.isfile(api_secrets_filename):
-            with open(api_secrets_filename, "r") as secrets:
-                config = json.load(secrets)
-        # If there is a secrets file specified and it does not exist log a warning to indicate that the specified file
-        # could not be found and create an empty config
-        elif api_secrets_filename is not None and (not os.path.exists(api_secrets_filename) or not os.path.isfile(api_secrets_filename)):
-            logging.warning(f"Provided secrets file of {api_secrets_filename} can not be found, please ensure you "
-                             f"have correctly specified the full path to the file or don't provide a secrets file to use "
-                             f"environment variables instead.")
-            config = {}
-        # If no secrets file is specified just create an empty config
-        else:
-            config = {}
+        def _load_config_from_secrets_file():
 
-        # Populate the values for the api configuration preferring the secrets file over the environment variables
-        populated_api_config_values = {
-            key: config.get(api_config_key, {}).get(value["config"], os.getenv(value["env"], None))
-            for key, value in config_keys.items() if "proxy" not in key
-        }
+            # If there is a secrets file specified and it exists get the details from it
+            if api_secrets_filename is not None and os.path.exists(api_secrets_filename) and os.path.isfile(api_secrets_filename):
+                with open(api_secrets_filename, "r") as secrets:
+                    config = json.load(secrets)
 
-        # Populate the values for the proxy preferring the secrets file over the environment variables
-        populated_proxy_values = {
-            key.replace("proxy_", ""): config.get(proxy_config_key, {}).get(value["config"], os.getenv(value["env"], None))
-            for key, value in config_keys.items() if "proxy" in key
-        }
+            # If there is a secrets file specified and it does not exist log a warning to indicate that the specified file
+            # could not be found and create an empty config
+            elif api_secrets_filename is not None and (not os.path.exists(api_secrets_filename) or not os.path.isfile(api_secrets_filename)):
+                logging.warning(f"Provided secrets file of {api_secrets_filename} can not be found, please ensure you "
+                                 f"have correctly specified the full path to the file or don't provide a secrets file to use "
+                                 f"environment variables instead.")
+                config = {}
+            # If no secrets file is specified just create an empty config
+            else:
+                config = {}
+
+            return config
+
+        def _get_access_api_config():
+
+            config = _load_config_from_secrets_file()
+
+            # Populate the values for the api configuration preferring the secrets file over the environment variables
+            populated_api_config_values = {
+                key: config.get(api_config_key, {}).get(value["config"], os.getenv(value["env"], None))
+                for key, value in config_keys.items() if "proxy" not in key
+            }
+
+            return populated_api_config_values
+
+        def _get_proxy_api_config():
+
+            config = _load_config_from_secrets_file()
+
+            # Populate the values for the proxy preferring the secrets file over the environment variables
+            populated_proxy_values = {
+                key.replace("proxy_", ""): config.get(proxy_config_key, {}).get(value["config"], os.getenv(value["env"], None))
+                for key, value in config_keys.items() if "proxy" in key
+            }
+
+            return populated_proxy_values
+
+        populated_api_config_values = _get_access_api_config()
+        populated_proxy_values = _get_proxy_api_config()
 
         # If the proxy address is missing ensure that no proxy is used in the ApiConfiguration
         if populated_proxy_values.get("address", None) is None:

--- a/sdk/lusid/utilities/config_keys.json
+++ b/sdk/lusid/utilities/config_keys.json
@@ -42,5 +42,9 @@
   "proxy_password": {
       "env": "FBN_PROXY_PASSWORD",
       "config": "password"
+  },
+    "access_token": {
+      "env": "FBN_LUSID_ACCESS_TOKEN",
+      "config": "accessToken"
   }
 }

--- a/sdk/tests/utilities/credentials_source.py
+++ b/sdk/tests/utilities/credentials_source.py
@@ -28,6 +28,10 @@ class CredentialsSource:
         return f"{testcase_func.__name__}: {param.args[0]}"
 
     @classmethod
+    def fetch_pat(cls):
+        return os.getenv("FBN_LUSID_ACCESS_TOKEN", None)
+
+    @classmethod
     def fetch_credentials(cls):
         credentials = cls.secrets_path()
 
@@ -60,8 +64,8 @@ class CredentialsSource:
                 if value is None:
                     vars[key] = config_vars[key]
 
-        if None in vars.values():
-            assert False, "Source test configuration missing values from both secrets file and environment variables"
+        # if access_token is not None and None in vars.values():
+        #     assert False, "Source test configuration missing values from both secrets file and environment variables"
 
         vars_optional = {
             "app_name": os.getenv("FBN_APP_NAME", None),

--- a/sdk/tests/utilities/credentials_source.py
+++ b/sdk/tests/utilities/credentials_source.py
@@ -64,8 +64,8 @@ class CredentialsSource:
                 if value is None:
                     vars[key] = config_vars[key]
 
-        # if access_token is not None and None in vars.values():
-        #     assert False, "Source test configuration missing values from both secrets file and environment variables"
+        if None in vars.values():
+            assert False, "Source test configuration missing values from both secrets file and environment variables"
 
         vars_optional = {
             "app_name": os.getenv("FBN_APP_NAME", None),

--- a/sdk/tests/utilities/test_api_client_builder.py
+++ b/sdk/tests/utilities/test_api_client_builder.py
@@ -33,7 +33,6 @@ class ApiClientBuilderTests(unittest.TestCase):
     def test_missing_from_config_file_throws(self, _, missing_attributes, token):
         """
         Tests that if some required fields are missing from the ApiConfiguration an error is thrown
-
         :return:
         """
         # Create an ApiConfiguration with all values populated

--- a/sdk/tests/utilities/test_api_client_builder.py
+++ b/sdk/tests/utilities/test_api_client_builder.py
@@ -31,6 +31,7 @@ class ApiClientBuilderTests(unittest.TestCase):
         ], testcase_func_name=CredentialsSource.custom_name_func
     )
     def test_missing_from_config_file_throws(self, _, missing_attributes, token):
+
         """
         Tests that if some required fields are missing from the ApiConfiguration an error is thrown
         :return:

--- a/sdk/tests/utilities/test_api_client_factory.py
+++ b/sdk/tests/utilities/test_api_client_factory.py
@@ -23,7 +23,7 @@ class UnknownImpl:
 
 
 source_config_details, config_keys = CredentialsSource.fetch_credentials(), CredentialsSource.fetch_config_keys()
-
+pat_token = CredentialsSource.fetch_pat()
 
 class RefreshingToken(UserString):
 
@@ -45,10 +45,10 @@ class RefreshingToken(UserString):
 
 class ApiFactory(unittest.TestCase):
 
-    def get_env_vars_wout_pat(self):
+    def get_env_vars_without_pat(self):
         env_vars = {config_keys[key]["env"]: value for key, value in source_config_details.items()if value is not None}
-        env_vars_wout_pat = {k:env_vars[k] for k in env_vars if k !="FBN_LUSID_ACCESS_TOKEN"}
-        return env_vars_wout_pat
+        env_vars_without_pat = {k:env_vars[k] for k in env_vars if k !="FBN_LUSID_ACCESS_TOKEN"}
+        return env_vars_without_pat
 
     def validate_api(self, api):
         result = api.get_instrument_identifier_types()
@@ -259,7 +259,7 @@ class ApiFactory(unittest.TestCase):
         communication with the id provider (if appropriate).
         """
 
-        with patch.dict('os.environ', self.get_env_vars_wout_pat(), clear=True):
+        with patch.dict('os.environ', self.get_env_vars_without_pat(), clear=True):
 
             responses = []
 
@@ -279,7 +279,7 @@ class ApiFactory(unittest.TestCase):
 
     def test_use_apifactory_multiple_threads(self):
 
-        with patch.dict('os.environ', self.get_env_vars_wout_pat(), clear=True):
+        with patch.dict('os.environ', self.get_env_vars_without_pat(), clear=True):
 
             access_token = str(ApiClientFactory(
                 api_secrets_filename=CredentialsSource.secrets_path()

--- a/sdk/tests/utilities/test_api_client_factory_auth_flow.py
+++ b/sdk/tests/utilities/test_api_client_factory_auth_flow.py
@@ -1,0 +1,112 @@
+import unittest
+import os
+from lusid import InstrumentsApi, ResourceListOfInstrumentIdTypeDescriptor
+from lusid.utilities import ApiClientFactory
+from utilities import CredentialsSource
+from unittest.mock import patch
+
+source_config_details, config_keys = CredentialsSource.fetch_credentials(), CredentialsSource.fetch_config_keys()
+pat_token = CredentialsSource.fetch_pat()
+
+class ApiFactory(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        # create a configured API client
+        cls.secrets = CredentialsSource.secrets_path()
+        cls.os_environ_dict_str = 'os.environ'
+
+    def validate_api(self, api):
+        result = api.get_instrument_identifier_types()
+        self.assertIsNotNone(result)
+        self.assertIsInstance(result, ResourceListOfInstrumentIdTypeDescriptor)
+        self.assertGreater(len(result.values), 0)
+
+    def get_pat_env_var(self):
+
+        pat_env_vars = {
+            "FBN_LUSID_API_URL": source_config_details["api_url"] ,
+            "FBN_LUSID_ACCESS_TOKEN": pat_token
+        }
+
+        return pat_env_vars
+
+    def get_env_vars_wout_pat(self):
+        env_vars = {config_keys[key]["env"]: value for key, value in source_config_details.items()if value is not None}
+        env_vars_wout_pat = {k:env_vars[k] for k in env_vars if k !="FBN_LUSID_ACCESS_TOKEN"}
+        return env_vars_wout_pat
+
+    def test_bad_pat_in_param_but_good_pat_in_env_vars(self):
+
+        with patch.dict(self.os_environ_dict_str, self.get_pat_env_var(), clear=True):
+            factory = ApiClientFactory(token="INVALID_TOKEN")
+            token = factory.api_client.configuration.access_token
+            self.assertEqual(token, "INVALID_TOKEN")
+
+    def test_bad_secrets_file_in_param_but_good_pat_in_env_vars(self):
+
+        with patch.dict(self.os_environ_dict_str, self.get_pat_env_var(), clear=True):
+
+            with self.assertLogs() as context_manager:
+
+                factory = ApiClientFactory(api_secrets_filename="INVALID_SECRETS")
+                api = factory.build(InstrumentsApi)
+
+                self.assertEqual(
+                    f"WARNING:root:Provided secrets file of INVALID_SECRETS can not be found, please ensure you have correctly specified the full path to the file or don't provide a secrets file to use environment variables instead.",
+                    context_manager.output[1],
+                )
+
+    def test_good_env_pat_but_no_param_pat(self):
+
+        with patch.dict(self.os_environ_dict_str, self.get_pat_env_var(), clear=True):
+
+            factory = ApiClientFactory()
+            api = factory.build(InstrumentsApi)
+            self.assertIsInstance(api, InstrumentsApi)
+            self.validate_api(api)
+
+    def test_no_env_pat_but_good_param_pat(self):
+
+        with patch.dict(self.os_environ_dict_str, {"FBN_LUSID_API_URL": source_config_details["api_url"]}, clear=True):
+
+            factory = ApiClientFactory(token=pat_token)
+            api = factory.build(InstrumentsApi)
+            self.assertIsInstance(api, InstrumentsApi)
+            self.validate_api(api)
+
+    def test_no_pat_but_good_secrets_file_as_param(self):
+
+        with patch.dict(self.os_environ_dict_str, self.get_secrets_env_vars(), clear=True):
+
+            factory = ApiClientFactory(api_secrets_filename=self.secrets)
+            api = factory.build(InstrumentsApi)
+            self.assertIsInstance(api, InstrumentsApi)
+            self.validate_api(api)
+
+    def test_none_str_param_pat_but_good_secrets_envs(self):
+
+        with patch.dict(self.os_environ_dict_str, self.get_secrets_env_vars(), clear=True):
+
+            factory = ApiClientFactory(token="None")
+            api = factory.build(InstrumentsApi)
+            self.assertIsInstance(api, InstrumentsApi)
+            self.validate_api(api)
+
+    def test_none_param_pat_but_good_secrets_envs(self):
+
+        with patch.dict(self.os_environ_dict_str, self.get_secrets_env_vars(), clear=True):
+
+            factory = ApiClientFactory(token=None)
+            api = factory.build(InstrumentsApi)
+            self.assertIsInstance(api, InstrumentsApi)
+            self.validate_api(api)
+
+    def test_none_secrets_param_but_good_env_pat(self):
+
+        with patch.dict(self.os_environ_dict_str, self.get_pat_env_var(), clear=True):
+
+            factory = ApiClientFactory(api_secrets_filename=None)
+            api = factory.build(InstrumentsApi)
+            self.assertIsInstance(api, InstrumentsApi)
+            self.validate_api(api)

--- a/sdk/tests/utilities/test_api_client_factory_auth_flow.py
+++ b/sdk/tests/utilities/test_api_client_factory_auth_flow.py
@@ -1,6 +1,6 @@
 import unittest
 import os
-from lusid import InstrumentsApi, ResourceListOfInstrumentIdTypeDescriptor
+from lusid import InstrumentsApi, ResourceListOfInstrumentIdTypeDescriptor, ApiException
 from lusid.utilities import ApiClientFactory
 from utilities import CredentialsSource
 from unittest.mock import patch
@@ -25,13 +25,13 @@ class ApiFactory(unittest.TestCase):
     def get_pat_env_var(self):
 
         pat_env_vars = {
-            "FBN_LUSID_API_URL": source_config_details["api_url"] ,
+            "FBN_LUSID_API_URL": source_config_details["api_url"],
             "FBN_LUSID_ACCESS_TOKEN": pat_token
         }
 
         return pat_env_vars
 
-    def get_env_vars_wout_pat(self):
+    def get_env_vars_without_pat(self):
         env_vars = {config_keys[key]["env"]: value for key, value in source_config_details.items()if value is not None}
         env_vars_wout_pat = {k:env_vars[k] for k in env_vars if k !="FBN_LUSID_ACCESS_TOKEN"}
         return env_vars_wout_pat
@@ -39,21 +39,31 @@ class ApiFactory(unittest.TestCase):
     def test_bad_pat_in_param_but_good_pat_in_env_vars(self):
 
         with patch.dict(self.os_environ_dict_str, self.get_pat_env_var(), clear=True):
-            factory = ApiClientFactory(token="INVALID_TOKEN")
-            token = factory.api_client.configuration.access_token
-            self.assertEqual(token, "INVALID_TOKEN")
+
+            try:
+
+                factory = ApiClientFactory(token="INVALID_TOKEN")
+                api = factory.build(InstrumentsApi)
+                api.get_instrument_identifier_types()
+
+            except ApiException as e:
+
+                self.assertEquals(401, e.status)
+
 
     def test_bad_secrets_file_in_param_but_good_pat_in_env_vars(self):
 
-        with patch.dict(self.os_environ_dict_str, self.get_pat_env_var(), clear=True):
+        all_env_vars = self.get_env_vars_without_pat()
+        all_env_vars["FBN_LUSID_ACCESS_TOKEN"] = pat_token
+
+        with patch.dict(self.os_environ_dict_str, all_env_vars, clear=True):
 
             with self.assertLogs() as context_manager:
 
-                factory = ApiClientFactory(api_secrets_filename="INVALID_SECRETS")
-                api = factory.build(InstrumentsApi)
+                factory = ApiClientFactory(api_secrets_filename="secrets_file_not_exist.json")
 
                 self.assertEqual(
-                    f"WARNING:root:Provided secrets file of INVALID_SECRETS can not be found, please ensure you have correctly specified the full path to the file or don't provide a secrets file to use environment variables instead.",
+                    f"WARNING:root:Provided secrets file of secrets_file_not_exist.json can not be found, please ensure you have correctly specified the full path to the file or don't provide a secrets file to use environment variables instead.",
                     context_manager.output[1],
                 )
 
@@ -77,7 +87,7 @@ class ApiFactory(unittest.TestCase):
 
     def test_no_pat_but_good_secrets_file_as_param(self):
 
-        with patch.dict(self.os_environ_dict_str, self.get_secrets_env_vars(), clear=True):
+        with patch.dict(self.os_environ_dict_str, self.get_env_vars_without_pat(), clear=True):
 
             factory = ApiClientFactory(api_secrets_filename=self.secrets)
             api = factory.build(InstrumentsApi)
@@ -86,7 +96,7 @@ class ApiFactory(unittest.TestCase):
 
     def test_none_str_param_pat_but_good_secrets_envs(self):
 
-        with patch.dict(self.os_environ_dict_str, self.get_secrets_env_vars(), clear=True):
+        with patch.dict(self.os_environ_dict_str, self.get_env_vars_without_pat(), clear=True):
 
             factory = ApiClientFactory(token="None")
             api = factory.build(InstrumentsApi)
@@ -95,7 +105,7 @@ class ApiFactory(unittest.TestCase):
 
     def test_none_param_pat_but_good_secrets_envs(self):
 
-        with patch.dict(self.os_environ_dict_str, self.get_secrets_env_vars(), clear=True):
+        with patch.dict(self.os_environ_dict_str, self.get_env_vars_without_pat(), clear=True):
 
             factory = ApiClientFactory(token=None)
             api = factory.build(InstrumentsApi)

--- a/sdk/tests/utilities/test_api_client_factory_auth_flow.py
+++ b/sdk/tests/utilities/test_api_client_factory_auth_flow.py
@@ -60,7 +60,7 @@ class ApiFactory(unittest.TestCase):
 
             with self.assertLogs() as context_manager:
 
-                factory = ApiClientFactory(api_secrets_filename="secrets_file_not_exist.json")
+                ApiClientFactory(api_secrets_filename="secrets_file_not_exist.json")
 
                 self.assertEqual(
                     f"WARNING:root:Provided secrets file of secrets_file_not_exist.json can not be found, please ensure you have correctly specified the full path to the file or don't provide a secrets file to use environment variables instead.",


### PR DESCRIPTION
# Pull Request Checklist

- [x] Read the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] Tests pass
- [x] Raised the PR against the `develop` branch

# Description of the PR

* The objective of this PR - allow users to pass in a PAT as an env variable.
* The env vars should only be used when the user does not explicitly pass a secret file or token as a param
* If, however, the user sets ApiFactory(token=None), then the logic should fall back to the env pat. This is need to support the sample-notbooks RefreshingToken() workflow. 

## High-level workflow for PAT as an env var

From a high-level, the new workflow is as follows:

1. Initialize the `ApiFactory` with no params but with a PAT in the env vars
2. The `ApiFactory` uses an `ApiClientBuilder` which loads configuration from the `ApiConfigurationLoader`
3. The `ApiConfigurationLoader`  loads the PAT from the env vars and uses the PAT for authentication (if a token has not been passed as a param directly) 

