### PR TITLE
SE-1741 Fix issue when specifying retries

### DIFF
--- a/sdk/lusid/utilities/lusid_retry.py
+++ b/sdk/lusid/utilities/lusid_retry.py
@@ -13,8 +13,11 @@ def lusidretry(fn):
         if not isinstance(retries, int):
             retries = 3
 
+        # remove the lusid_retries param from the kwargs
+        kwargs.pop("lusid_retries", None)
+
         tries = 0
-        while tries < retries:
+        while tries < retries+1:
             try:
                 return fn(*args, **kwargs)
             except ApiException as ex:

--- a/sdk/tests/utilities/test_retry.py
+++ b/sdk/tests/utilities/test_retry.py
@@ -131,3 +131,20 @@ class RetryTests(unittest.TestCase):
 
         self.assertEqual(ex.exception.status, 404)
         self.assertEqual(api.invocations, 3)
+
+    def test_providing_retry_override_with_no_retry_invokes_call(self):
+        api = self.factory.build(MockApi)
+
+        api.execute_retryable_call("Portfolio", name="Portfolio", lusid_retries=0)
+
+        self.assertEqual(api.invocations, 1)
+
+    def test_providing_retry_invokes_call(self):
+        with self.assertRaises(ApiException) as ex:
+            self.factory.build(lusid.InstrumentsApi).get_instrument(
+                identifier_type="doesnt_exist",
+                identifier="blah",
+                lusid_retries=1
+            )
+
+        self.assertEqual(ex.exception.status, 400)


### PR DESCRIPTION
# Pull Request Checklist

- [x] Read the [contributing guidelines](../blob/master/docs/CONTRIBUTING.md)
- [x] Tests pass
- [x] Raised the PR against the `develop` branch

# Description of the PR

Fixes an issue when specifying `lusid_retries=x` on api calls where x > 0

Also fixes an issue when x = 0 whereby api calls were not made