### PR TITLE
SE-1892: Update token_url setter on ApiConfiguration to append a toke…

### DIFF
--- a/sdk/lusid/utilities/api_configuration.py
+++ b/sdk/lusid/utilities/api_configuration.py
@@ -34,15 +34,19 @@ class ApiConfiguration:
 
     @token_url.setter
     def token_url(self, value):
-        # Check if we are using an Okta token url
-        if value is not None and re.search('^http(s)?:\/\/.*\.okta\.com\/oauth2\/.+', value, flags=re.IGNORECASE) is not None:
-            # Check if the Okta token url is missing the proper suffix
-            if re.search('\/v\d+\/token$', value, flags=re.IGNORECASE) is None:
-                self.__token_url = value.rstrip('/') + '/v1/token'
-            else:
-                self.__token_url = value
-        else:
-            self.__token_url = value
+        def format_token_url(url: str) -> str:
+            """
+            Given an Okta issuer url (ie: https://lusid-testdomain.okta.com/oauth2/asd8f7a98sdf89a7ad), this function
+            will return a full token url (ie: https://lusid-testdomain.okta.com/oauth2/asd8f7a98sdf89a7ad/v1/token)
+            :param url: The url to format
+            :return: An Okta token url (if the input is an Okta issuer url). The original url otherwise.
+            """
+            if url is not None and re.search('^http(s)?:\/\/.*\.okta\.com\/oauth2\/.+', url,
+                                             flags=re.IGNORECASE) is not None:
+                if re.search('\/v\d+\/token$', url, flags=re.IGNORECASE) is None:
+                    return url.rstrip('/') + '/v1/token'
+            return url
+        self.__token_url = format_token_url(value)
 
     @property
     def api_url(self):

--- a/sdk/lusid/utilities/api_configuration.py
+++ b/sdk/lusid/utilities/api_configuration.py
@@ -1,3 +1,6 @@
+import re
+
+
 class ApiConfiguration:
 
     def __init__(self, token_url=None, api_url=None, username=None, password=None, client_id=None, client_secret=None,
@@ -15,7 +18,7 @@ class ApiConfiguration:
         :param str certificate_filename: Name of the certificate file (.pem, .cer or .crt)
         :param lusid.utilities.ProxyConfig proxy_config: The proxy configuration to use
         """
-        self.__token_url = token_url
+        self.token_url = token_url
         self.__api_url = api_url
         self.__username = username
         self.__password = password
@@ -31,7 +34,15 @@ class ApiConfiguration:
 
     @token_url.setter
     def token_url(self, value):
-        self.__token_url = value
+        # Check if we are using an Okta token url
+        if value is not None and re.search('^http(s)?:\/\/.*\.okta\.com\/oauth2\/.+', value, flags=re.IGNORECASE) is not None:
+            # Check if the Okta token url is missing the proper suffix
+            if re.search('\/v\d+\/token$', value, flags=re.IGNORECASE) is None:
+                self.__token_url = value.rstrip('/') + '/v1/token'
+            else:
+                self.__token_url = value
+        else:
+            self.__token_url = value
 
     @property
     def api_url(self):

--- a/sdk/lusid/utilities/api_configuration.py
+++ b/sdk/lusid/utilities/api_configuration.py
@@ -41,11 +41,14 @@ class ApiConfiguration:
             :param url: The url to format
             :return: An Okta token url (if the input is an Okta issuer url). The original url otherwise.
             """
-            if url is not None and re.search('^http(s)?:\/\/.*\.okta\.com\/oauth2\/.+', url,
-                                             flags=re.IGNORECASE) is not None:
-                if re.search('\/v\d+\/token$', url, flags=re.IGNORECASE) is None:
-                    return url.rstrip('/') + '/v1/token'
+            if (url is not None and
+                    # and it's an Okta oauth2 URL
+                    re.search('^http(s)?:\/\/.*\.okta\.com\/oauth2\/.+', url, flags=re.IGNORECASE) is not None and
+                    # and it's missing the token suffix
+                    re.search('\/v\d+\/token$', url, flags=re.IGNORECASE) is None):
+                return url.rstrip('/') + '/v1/token'
             return url
+
         self.__token_url = format_token_url(value)
 
     @property

--- a/sdk/tests/utilities/test_api_configuration.py
+++ b/sdk/tests/utilities/test_api_configuration.py
@@ -1,0 +1,60 @@
+import unittest
+
+from parameterized import parameterized
+
+from lusid import ApiConfiguration
+
+
+class ApiConfigurationTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.valid_okta_url_regex = '^http(s)?:\/\/.*\.okta\.com\/oauth2\/.*\/v\d+\/token$'
+
+    @parameterized.expand([
+        'https://lusid-testdomain.okta.com/oauth2/sdf7a6sd8f76asd976f/',
+        'http://lusid-testdomain.okta.com/oauth2/sdf7a6sd8f76asd976f/',
+        'https://lusid-testdomain.okta.com/oauth2/sdf7a6sd8f76asd976f',
+        'http://lusid-testdomain.okta.com/oauth2/sdf7a6sd8f76asd976f'
+    ])
+    def test_okta_token_url_without_proper_suffix(self, token_url):
+        api_config = ApiConfiguration(token_url=token_url)
+        self.assertRegex(api_config.token_url, self.valid_okta_url_regex)
+
+
+    @parameterized.expand([
+        'https://lusid-testdomain.okta.com/oauth2/sdf7a6sd8f76asd976f/v1/token',
+        'https://lusid-testdomain.okta.com/oauth2/sdf7a6sd8f76asd976f/v1/token/',
+        'http://lusid-testdomain.okta.com/oauth2/sdf7a6sd8f76asd976f/v1/token',
+        'http://lusid-testdomain.okta.com/oauth2/sdf7a6sd8f76asd976f/v1/token/',
+        'https://lusid-testdomain.okta.com/oauth2/sdf7a6sd8f76asd976f/v2/token',
+        'https://lusid-testdomain.okta.com/oauth2/sdf7a6sd8f76asd976f/v2/token/',
+        'http://lusid-testdomain.okta.com/oauth2/sdf7a6sd8f76asd976f/v2/token',
+        'http://lusid-testdomain.okta.com/oauth2/sdf7a6sd8f76asd976f/v2/token/',
+        'https://lusid-testdomain.okta.com/oauth2/sdf7a6sd8f76asd976f/v10/token',
+        'https://lusid-testdomain.okta.com/oauth2/sdf7a6sd8f76asd976f/v10/token/',
+        'http://lusid-testdomain.okta.com/oauth2/sdf7a6sd8f76asd976f/v10/token',
+        'http://lusid-testdomain.okta.com/oauth2/sdf7a6sd8f76asd976f/v10/token/',
+    ])
+    def test_okta_token_url_with_proper_suffix(self, token_url):
+        api_config = ApiConfiguration(token_url=token_url)
+        self.assertRegex(api_config.token_url, self.valid_okta_url_regex)
+
+    @parameterized.expand([
+        'https://foo.bar.com/oauth2/asd34fhas34dufhasdf/v1/token',
+        'https://foo.bar.com/oauth2/asdfh756asdufhasdf/v1/token/',
+        'http://foo.bar.com/oauth2/asdfhasdufhas345df/v1/token',
+        'http://foo.bar.com/oauth2/asd234fhasdufhasdf/v1/token/',
+    ])
+    def test_non_okta_token_url_with_proper_suffix(self, token_url):
+        api_config = ApiConfiguration(token_url=token_url)
+        self.assertEqual(api_config.token_url, token_url)
+
+    @parameterized.expand([
+        'https://foo.bar.com/oauth2/asd34fhas34dufhasdf',
+        'https://foo.bar.com/oauth2/asdfh756asdufhasdf/',
+        'http://foo.bar.com/oauth2/asdfhasdufhas345df',
+        'http://foo.bar.com/oauth2/asd234fhasdufhasdf/',
+    ])
+    def test_non_okta_token_url_without_proper_suffix(self, token_url):
+        api_config = ApiConfiguration(token_url=token_url)
+        self.assertEqual(api_config.token_url, token_url)

--- a/sdk/tests/utilities/test_api_configuration.py
+++ b/sdk/tests/utilities/test_api_configuration.py
@@ -11,17 +11,12 @@ class ApiConfigurationTests(unittest.TestCase):
         cls.valid_okta_url_regex = '^http(s)?:\/\/.*\.okta\.com\/oauth2\/.*\/v\d+\/token$'
 
     @parameterized.expand([
+        # Okta urls without proper suffix
         'https://lusid-testdomain.okta.com/oauth2/sdf7a6sd8f76asd976f/',
         'http://lusid-testdomain.okta.com/oauth2/sdf7a6sd8f76asd976f/',
         'https://lusid-testdomain.okta.com/oauth2/sdf7a6sd8f76asd976f',
-        'http://lusid-testdomain.okta.com/oauth2/sdf7a6sd8f76asd976f'
-    ])
-    def test_okta_token_url_without_proper_suffix(self, token_url):
-        api_config = ApiConfiguration(token_url=token_url)
-        self.assertRegex(api_config.token_url, self.valid_okta_url_regex)
-
-
-    @parameterized.expand([
+        'http://lusid-testdomain.okta.com/oauth2/sdf7a6sd8f76asd976f',
+        # Okta urls with proper suffix
         'https://lusid-testdomain.okta.com/oauth2/sdf7a6sd8f76asd976f/v1/token',
         'https://lusid-testdomain.okta.com/oauth2/sdf7a6sd8f76asd976f/v1/token/',
         'http://lusid-testdomain.okta.com/oauth2/sdf7a6sd8f76asd976f/v1/token',
@@ -30,31 +25,28 @@ class ApiConfigurationTests(unittest.TestCase):
         'https://lusid-testdomain.okta.com/oauth2/sdf7a6sd8f76asd976f/v2/token/',
         'http://lusid-testdomain.okta.com/oauth2/sdf7a6sd8f76asd976f/v2/token',
         'http://lusid-testdomain.okta.com/oauth2/sdf7a6sd8f76asd976f/v2/token/',
+        # 2 digit version
         'https://lusid-testdomain.okta.com/oauth2/sdf7a6sd8f76asd976f/v10/token',
         'https://lusid-testdomain.okta.com/oauth2/sdf7a6sd8f76asd976f/v10/token/',
         'http://lusid-testdomain.okta.com/oauth2/sdf7a6sd8f76asd976f/v10/token',
-        'http://lusid-testdomain.okta.com/oauth2/sdf7a6sd8f76asd976f/v10/token/',
+        'http://lusid-testdomain.okta.com/oauth2/sdf7a6sd8f76asd976f/v10/token/'
     ])
-    def test_okta_token_url_with_proper_suffix(self, token_url):
+    def test_okta_token_url_without_proper_suffix(self, token_url):
         api_config = ApiConfiguration(token_url=token_url)
         self.assertRegex(api_config.token_url, self.valid_okta_url_regex)
 
     @parameterized.expand([
+        # Non okta urls with a token suffix
         'https://foo.bar.com/oauth2/asd34fhas34dufhasdf/v1/token',
         'https://foo.bar.com/oauth2/asdfh756asdufhasdf/v1/token/',
         'http://foo.bar.com/oauth2/asdfhasdufhas345df/v1/token',
         'http://foo.bar.com/oauth2/asd234fhasdufhasdf/v1/token/',
-    ])
-    def test_non_okta_token_url_with_proper_suffix(self, token_url):
-        api_config = ApiConfiguration(token_url=token_url)
-        self.assertEqual(api_config.token_url, token_url)
-
-    @parameterized.expand([
+        # Non okta urls without a token suffix
         'https://foo.bar.com/oauth2/asd34fhas34dufhasdf',
         'https://foo.bar.com/oauth2/asdfh756asdufhasdf/',
         'http://foo.bar.com/oauth2/asdfhasdufhas345df',
-        'http://foo.bar.com/oauth2/asd234fhasdufhasdf/',
+        'http://foo.bar.com/oauth2/asd234fhasdufhasdf/'
     ])
-    def test_non_okta_token_url_without_proper_suffix(self, token_url):
+    def test_non_okta_token_url_with_proper_suffix(self, token_url):
         api_config = ApiConfiguration(token_url=token_url)
         self.assertEqual(api_config.token_url, token_url)

--- a/sdk/tests/utilities/test_api_configuration.py
+++ b/sdk/tests/utilities/test_api_configuration.py
@@ -13,23 +13,15 @@ class ApiConfigurationTests(unittest.TestCase):
     @parameterized.expand([
         # Okta urls without proper suffix
         'https://lusid-testdomain.okta.com/oauth2/sdf7a6sd8f76asd976f/',
-        'http://lusid-testdomain.okta.com/oauth2/sdf7a6sd8f76asd976f/',
         'https://lusid-testdomain.okta.com/oauth2/sdf7a6sd8f76asd976f',
-        'http://lusid-testdomain.okta.com/oauth2/sdf7a6sd8f76asd976f',
         # Okta urls with proper suffix
         'https://lusid-testdomain.okta.com/oauth2/sdf7a6sd8f76asd976f/v1/token',
         'https://lusid-testdomain.okta.com/oauth2/sdf7a6sd8f76asd976f/v1/token/',
-        'http://lusid-testdomain.okta.com/oauth2/sdf7a6sd8f76asd976f/v1/token',
-        'http://lusid-testdomain.okta.com/oauth2/sdf7a6sd8f76asd976f/v1/token/',
         'https://lusid-testdomain.okta.com/oauth2/sdf7a6sd8f76asd976f/v2/token',
         'https://lusid-testdomain.okta.com/oauth2/sdf7a6sd8f76asd976f/v2/token/',
-        'http://lusid-testdomain.okta.com/oauth2/sdf7a6sd8f76asd976f/v2/token',
-        'http://lusid-testdomain.okta.com/oauth2/sdf7a6sd8f76asd976f/v2/token/',
         # 2 digit version
         'https://lusid-testdomain.okta.com/oauth2/sdf7a6sd8f76asd976f/v10/token',
-        'https://lusid-testdomain.okta.com/oauth2/sdf7a6sd8f76asd976f/v10/token/',
-        'http://lusid-testdomain.okta.com/oauth2/sdf7a6sd8f76asd976f/v10/token',
-        'http://lusid-testdomain.okta.com/oauth2/sdf7a6sd8f76asd976f/v10/token/'
+        'https://lusid-testdomain.okta.com/oauth2/sdf7a6sd8f76asd976f/v10/token/'
     ])
     def test_okta_token_url_without_proper_suffix(self, token_url):
         api_config = ApiConfiguration(token_url=token_url)
@@ -39,13 +31,9 @@ class ApiConfigurationTests(unittest.TestCase):
         # Non okta urls with a token suffix
         'https://foo.bar.com/oauth2/asd34fhas34dufhasdf/v1/token',
         'https://foo.bar.com/oauth2/asdfh756asdufhasdf/v1/token/',
-        'http://foo.bar.com/oauth2/asdfhasdufhas345df/v1/token',
-        'http://foo.bar.com/oauth2/asd234fhasdufhasdf/v1/token/',
         # Non okta urls without a token suffix
         'https://foo.bar.com/oauth2/asd34fhas34dufhasdf',
-        'https://foo.bar.com/oauth2/asdfh756asdufhasdf/',
-        'http://foo.bar.com/oauth2/asdfhasdufhas345df',
-        'http://foo.bar.com/oauth2/asd234fhasdufhasdf/'
+        'https://foo.bar.com/oauth2/asdfh756asdufhasdf/'
     ])
     def test_non_okta_token_url_with_proper_suffix(self, token_url):
         api_config = ApiConfiguration(token_url=token_url)


### PR DESCRIPTION
…n version if its missing

# Pull Request Checklist

- [x] Read the [contributing guidelines](../blob/master/docs/CONTRIBUTING.md)
- [x] Tests pass
- [x] Raised the PR against the `develop` branch

# Description of the PR

When Lydia bootstraps a new client domain, it adds the token URL to the parameter store without the '/v1/token' suffix. This results in 404 responses unless the token version is appended afterwards. When generating the client secrets file (or the environment vars) from the LUSID UI, the token version is already appended; hence why we don't typically have any issues. This change checks if the token URL is missing the version suffix in APIConfiguration and appends a default one if necessary. 
