### PR TITLE
SENG-50 Generate ids that can be disposed during test tear downs

### DIFF
--- a/sdk/tests/tutorials/ibor/test_reference_portfolios.py
+++ b/sdk/tests/tutorials/ibor/test_reference_portfolios.py
@@ -1,19 +1,20 @@
-import unittest
-import pytz
-import json
 import logging
-
+import unittest
 from datetime import datetime
+
+import pytz
+from lusidfeature import lusid_feature
 
 import lusid
 import lusid.models as models
-
-from lusidfeature import lusid_feature
-from utilities import TestDataUtilities
+from lusid import ApiException
+from utilities import IdGenerator
 from utilities import InstrumentLoader
+from utilities import TestDataUtilities
 
 
 class ReferencePortfolio(unittest.TestCase):
+
     @classmethod
     def setUpClass(cls):
 
@@ -33,16 +34,26 @@ class ReferencePortfolio(unittest.TestCase):
         cls.instrument_loader = InstrumentLoader(cls.instruments_api)
         cls.instrument_ids = cls.instrument_loader.load_instruments()
 
+        cls.id_generator = IdGenerator(default_scope=TestDataUtilities.tutorials_scope)
+
+    @classmethod
+    def tearDownClass(cls):
+        for _, scope, code in cls.id_generator.pop_scope_and_codes():
+            try:
+                cls.portfolios_api.delete_portfolio(scope, code)
+            except ApiException as ex:
+                print(ex)
+
     @lusid_feature("F39")
     def test_create_reference_portfolio(self):
 
-        f39_reference_portfolio_code = "F39p_ReferencePortfolioCode"
+        _, _, portfolio_code = self.id_generator.generate_scope_and_code("portfolio")
         f39_reference_portfolio_name = "F39p_Reference Portfolio Name"
 
         # Details of the new reference portfolio to be created
         request = models.CreateReferencePortfolioRequest(
             display_name=f39_reference_portfolio_name,
-            code=f39_reference_portfolio_code,
+            code=portfolio_code,
         )
 
         # Create the reference portfolio in LUSID in the tutorials scope
@@ -53,25 +64,19 @@ class ReferencePortfolio(unittest.TestCase):
 
         self.assertEqual(result.id.code, request.code)
 
-        # Delete portfolio once the test is complete
-        self.portfolios_api.delete_portfolio(
-            scope=TestDataUtilities.tutorials_scope, code=f39_reference_portfolio_code
-        )
-
     @lusid_feature("F40")
     def test_upsert_reference_portfolio_constituents(self):
 
         constituent_weights = [10, 20, 30, 15, 25]
         effective_date = datetime(year=2021, month=3, day=29, tzinfo=pytz.UTC)
 
-        f40_reference_portfolio_code = "F40p_ReferencePortfolioCode"
+        _, _, portfolio_code = self.id_generator.generate_scope_and_code("portfolio")
         f40_reference_portfolio_name = "F40p_Reference Portfolio Name"
-
 
         # Create a new reference portfolio
         request = models.CreateReferencePortfolioRequest(
             display_name=f40_reference_portfolio_name,
-            code=f40_reference_portfolio_code,
+            code=portfolio_code,
             created=effective_date,
         )
 
@@ -107,7 +112,7 @@ class ReferencePortfolio(unittest.TestCase):
         # Make the upsert request via the reference portfolio API
         self.reference_portfolio_api.upsert_reference_portfolio_constituents(
             scope=TestDataUtilities.tutorials_scope,
-            code=f40_reference_portfolio_code,
+            code=portfolio_code,
             upsert_reference_portfolio_constituents_request=bulk_constituent_request,
         )
 
@@ -115,7 +120,7 @@ class ReferencePortfolio(unittest.TestCase):
         constituent_holdings = (
             self.reference_portfolio_api.get_reference_portfolio_constituents(
                 scope=TestDataUtilities.tutorials_scope,
-                code=f40_reference_portfolio_code,
+                code=portfolio_code,
             )
         )
 
@@ -124,17 +129,12 @@ class ReferencePortfolio(unittest.TestCase):
 
         # Validate instruments on holdings
         for constituent, upserted_instrument in zip(
-            constituent_holdings.constituents, self.instrument_ids
+                constituent_holdings.constituents, self.instrument_ids
         ):
             self.assertEqual(constituent.instrument_uid, upserted_instrument)
 
         # Validate holding weights
         for constituent, weight in zip(
-            constituent_holdings.constituents, constituent_weights
+                constituent_holdings.constituents, constituent_weights
         ):
             self.assertEqual(constituent.weight, weight)
-
-        # Delete portfolio once the test is complete
-        self.portfolios_api.delete_portfolio(
-            scope=TestDataUtilities.tutorials_scope, code=f40_reference_portfolio_code
-        )

--- a/sdk/tests/tutorials/ibor/test_reference_portfolios.py
+++ b/sdk/tests/tutorials/ibor/test_reference_portfolios.py
@@ -34,7 +34,7 @@ class ReferencePortfolio(unittest.TestCase):
         cls.instrument_loader = InstrumentLoader(cls.instruments_api)
         cls.instrument_ids = cls.instrument_loader.load_instruments()
 
-        cls.id_generator = IdGenerator(default_scope=TestDataUtilities.tutorials_scope)
+        cls.id_generator = IdGenerator(scope=TestDataUtilities.tutorials_scope)
 
     @classmethod
     def tearDownClass(cls):

--- a/sdk/tests/utilities/__init__.py
+++ b/sdk/tests/utilities/__init__.py
@@ -4,3 +4,4 @@ from utilities.test_data_utilities import TestDataUtilities
 from utilities.token_utilities import TokenUtilities
 from utilities.temp_file_manager import TempFileManager
 from utilities.mock_api_response import MockApiResponse
+from utilities.id_generator import IdGenerator

--- a/sdk/tests/utilities/id_generator.py
+++ b/sdk/tests/utilities/id_generator.py
@@ -3,19 +3,23 @@ import uuid
 
 class IdGenerator:
 
-    def __init__(self, default_scope=None):
+    default_scope = "sdk_example"
+
+    def __init__(self, scope=default_scope):
         """
 
         Parameters
         ----------
-        default_scope   scope to use for subsequent generate calls when do scope is provided
+        scope : str, optional
+          scope to use for subsequent calls to generate ids, when no scope is provided defaults
+          to `sdk_example`
         """
-        self.default_scope = default_scope if default_scope is not None else "sdk_example"
+        self.scope = scope if scope is not None else self.default_scope
         self._scope_and_codes = set()
 
     def generate_scope_and_code(self, entity, scope=None, code_prefix=None):
         """
-        Generate a scope ond code
+        Generate a scope and code
 
         Parameters
         ----------

--- a/sdk/tests/utilities/id_generator.py
+++ b/sdk/tests/utilities/id_generator.py
@@ -1,0 +1,62 @@
+import uuid
+
+
+class IdGenerator:
+
+    def __init__(self, default_scope=None):
+        """
+
+        Parameters
+        ----------
+        default_scope   scope to use for subsequent generate calls when do scope is provided
+        """
+        self.default_scope = default_scope if default_scope is not None else "sdk_example"
+        self._scope_and_codes = set()
+
+    def generate_scope_and_code(self, entity, scope=None, code_prefix=None):
+        """
+        Generate a scope ond code
+
+        Parameters
+        ----------
+        entity : str
+            User defined string to describe the entity the scope and code is being generated for. This is returned
+            when calling ``pop_scope_and_codes``
+        scope : str, optional
+            Scope to use, if not supplied the default one will be used
+        code_prefix : str, optional
+            Prefix for the generated code
+
+        Returns
+        -------
+        (str, str, str)
+            The generated (entity, scope, code)
+
+        """
+        scope = scope if scope is not None else self.default_scope
+
+        code = str(uuid.uuid4())
+        code = code if code_prefix is None else f"{code_prefix}{code}"
+
+        item = (entity, scope, code)
+
+        self._scope_and_codes.add(item)
+        return item
+
+    def clear(self):
+        """
+        Clears all generated ids
+        """
+        self._scope_and_codes.clear()
+
+    def pop_scope_and_codes(self):
+        """
+        Generator returning the generated scope and code. Generated ids are deleted after being returned
+
+        Yields
+        -------
+        (str, str, str)
+            The generated (entity, scope, code)
+        """
+        while self._scope_and_codes:
+            yield self._scope_and_codes.pop()

--- a/sdk/tests/utilities/test_id_generator.py
+++ b/sdk/tests/utilities/test_id_generator.py
@@ -1,0 +1,81 @@
+import unittest
+
+from . import IdGenerator
+from parameterized import parameterized
+
+
+class IdGeneratorTests(unittest.TestCase):
+
+    def test_use_default_scope_when_not_specified(self):
+        id_generator = IdGenerator()
+        self.assertEqual("sdk_example", id_generator.default_scope)
+
+    @parameterized.expand([
+        ["custom-scope"],
+        [""]
+    ])
+    def test_uses_provided_scope(self, scope):
+        id_generator = IdGenerator(scope)
+        self.assertEqual(scope, id_generator.default_scope)
+
+    def test_explicit_none_scope_uses_default(self):
+        id_generator = IdGenerator(None)
+        self.assertEqual("sdk_example", id_generator.default_scope)
+
+    @parameterized.expand([
+        ["default scope", None, "sdk_example"],
+        ["override scope", "new-scope", "new-scope"]
+    ])
+    def test_generate_scope_and_code(self, _, scope, expected_scope):
+        id_generator = IdGenerator()
+        gen_entity, gen_scope, gen_code = id_generator.generate_scope_and_code("portfolio", scope=scope)
+
+        self.assertEqual("portfolio", gen_entity)
+        self.assertEqual(expected_scope, gen_scope)
+        self.assertIsNotNone(gen_code)
+        self.assertIsNot("", gen_code)
+
+    def test_generate_scope_and_code_with_scope_prefix(self):
+        code_prefix= "abc-"
+        id_generator = IdGenerator()
+        gen_entity, gen_scope, gen_code = id_generator.generate_scope_and_code("portfolio", code_prefix=code_prefix)
+
+        self.assertEqual("portfolio", gen_entity)
+        self.assertEqual("sdk_example", gen_scope)
+        self.assertIsNotNone(gen_code)
+        self.assertTrue(gen_code.startswith(code_prefix))
+
+    def test_clear_scope_and_code(self):
+        id_generator = IdGenerator()
+        id_generator.generate_scope_and_code("portfolio")
+
+        vals = id_generator.pop_scope_and_codes()
+        self.assertEqual(1, len(list(vals)))
+
+        id_generator.clear()
+
+        self.assertEqual(0, len(list(vals)))
+
+    def test_get_scope_and_code(self):
+        id_generator = IdGenerator()
+        entity, scope, code = id_generator.generate_scope_and_code("portfolio")
+
+        val = next(id_generator.pop_scope_and_codes(), None)
+
+        self.assertEqual(scope, val[1])
+
+        val = next(id_generator.pop_scope_and_codes(), None)
+        self.assertIsNone(val)
+
+    def test_get_multiple_scope_and_codes(self):
+        id_generator = IdGenerator()
+        n = 5
+
+        vals = {
+            id_generator.generate_scope_and_code("portfolio")
+            for _ in range(n)
+        }
+
+        gen_vals = set(id_generator.pop_scope_and_codes())
+        self.assertEqual(n, len(gen_vals))
+        self.assertSetEqual(vals, gen_vals)

--- a/sdk/tests/utilities/test_id_generator.py
+++ b/sdk/tests/utilities/test_id_generator.py
@@ -8,7 +8,7 @@ class IdGeneratorTests(unittest.TestCase):
 
     def test_use_default_scope_when_not_specified(self):
         id_generator = IdGenerator()
-        self.assertEqual("sdk_example", id_generator.default_scope)
+        self.assertEqual(IdGenerator.default_scope, id_generator.scope)
 
     @parameterized.expand([
         ["custom-scope"],
@@ -16,14 +16,14 @@ class IdGeneratorTests(unittest.TestCase):
     ])
     def test_uses_provided_scope(self, scope):
         id_generator = IdGenerator(scope)
-        self.assertEqual(scope, id_generator.default_scope)
+        self.assertEqual(scope, id_generator.scope)
 
     def test_explicit_none_scope_uses_default(self):
         id_generator = IdGenerator(None)
-        self.assertEqual("sdk_example", id_generator.default_scope)
+        self.assertEqual(IdGenerator.default_scope, id_generator.scope)
 
     @parameterized.expand([
-        ["default scope", None, "sdk_example"],
+        ["default scope", None, IdGenerator.default_scope],
         ["override scope", "new-scope", "new-scope"]
     ])
     def test_generate_scope_and_code(self, _, scope, expected_scope):
@@ -41,7 +41,7 @@ class IdGeneratorTests(unittest.TestCase):
         gen_entity, gen_scope, gen_code = id_generator.generate_scope_and_code("portfolio", code_prefix=code_prefix)
 
         self.assertEqual("portfolio", gen_entity)
-        self.assertEqual("sdk_example", gen_scope)
+        self.assertEqual(IdGenerator.default_scope, gen_scope)
         self.assertIsNotNone(gen_code)
         self.assertTrue(gen_code.startswith(code_prefix))
 


### PR DESCRIPTION
# Pull Request Checklist

- [x] Read the [contributing guidelines](../blob/master/docs/CONTRIBUTING.md)
- [x] Tests pass
- [x] Raised the PR against the `develop` branch

# Description of the PR

Create an id generator that will store ids that can be used to delete entities in test tear downs. This PR implements for Reference Portfolios and once approved can be rolled out to other examples