### PR TITLE
CTECH-1344: Fixes tests for base url, and access token.

### DIFF
--- a/sdk/docker-compose.yml
+++ b/sdk/docker-compose.yml
@@ -21,14 +21,14 @@ services:
     environment:
       - FBN_CLIENT_ID
       - FBN_CLIENT_SECRET
-      - FBN_LUSID_API_URL
       - FBN_PASSWORD
       - FBN_TOKEN_URL
       - FBN_USERNAME
       - FBN_PROXY_ADDRESS=http://tinyproxy:8888
       - FBN_PROXY_USERNAME=user
       - FBN_PROXY_PASSWORD=password
-      - FBN_LUSID_ACCESS_TOKEN
+      - FBN_LUSID_API_URL=${FBN_BASE_API_URL}/api
+      - FBN_ACCESS_TOKEN
     volumes:
       - .:/usr/src
     depends_on:

--- a/sdk/lusid/utilities/config_keys.json
+++ b/sdk/lusid/utilities/config_keys.json
@@ -44,7 +44,7 @@
       "config": "password"
   },
     "access_token": {
-      "env": "FBN_LUSID_ACCESS_TOKEN",
+      "env": "FBN_ACCESS_TOKEN",
       "config": "accessToken"
   }
 }

--- a/sdk/tests/utilities/credentials_source.py
+++ b/sdk/tests/utilities/credentials_source.py
@@ -29,7 +29,7 @@ class CredentialsSource:
 
     @classmethod
     def fetch_pat(cls):
-        return os.getenv("FBN_LUSID_ACCESS_TOKEN", None)
+        return os.getenv("FBN_ACCESS_TOKEN", None)
 
     @classmethod
     def fetch_credentials(cls):

--- a/sdk/tests/utilities/test_api_client_factory.py
+++ b/sdk/tests/utilities/test_api_client_factory.py
@@ -49,7 +49,7 @@ class ApiFactory(unittest.TestCase):
 
     def get_env_vars_without_pat(self):
         env_vars = {config_keys[key]["env"]: value for key, value in source_config_details.items() if value is not None}
-        env_vars_without_pat = {k: env_vars[k] for k in env_vars if k != "FBN_LUSID_ACCESS_TOKEN"}
+        env_vars_without_pat = {k: env_vars[k] for k in env_vars if k != "FBN_ACCESS_TOKEN"}
         return env_vars_without_pat
 
     def validate_api(self, api):

--- a/sdk/tests/utilities/test_api_client_factory_auth_flow.py
+++ b/sdk/tests/utilities/test_api_client_factory_auth_flow.py
@@ -27,7 +27,7 @@ class ApiFactory(unittest.TestCase):
 
         pat_env_vars = {
             "FBN_LUSID_API_URL": self.source_config_details["api_url"],
-            "FBN_LUSID_ACCESS_TOKEN": self.pat_token
+            "FBN_ACCESS_TOKEN": self.pat_token
         }
 
         return pat_env_vars
@@ -35,7 +35,7 @@ class ApiFactory(unittest.TestCase):
     def get_env_vars_without_pat(self):
         env_vars = {self.config_keys[key]["env"]: value for key, value in self.source_config_details.items() if
                     value is not None}
-        env_vars_wout_pat = {k: env_vars[k] for k in env_vars if k != "FBN_LUSID_ACCESS_TOKEN"}
+        env_vars_wout_pat = {k: env_vars[k] for k in env_vars if k != "FBN_ACCESS_TOKEN"}
         return env_vars_wout_pat
 
     @unittest.skipIf(not CredentialsSource.fetch_credentials().__contains__("access_token"), "do not run if no token present")
@@ -57,7 +57,7 @@ class ApiFactory(unittest.TestCase):
     def test_bad_secrets_file_in_param_but_good_pat_in_env_vars(self):
 
         all_env_vars = self.get_env_vars_without_pat()
-        all_env_vars["FBN_LUSID_ACCESS_TOKEN"] = self.pat_token
+        all_env_vars["FBN_ACCESS_TOKEN"] = self.pat_token
 
         with patch.dict(self.os_environ_dict_str, all_env_vars, clear=True):
             with self.assertLogs() as context_manager:


### PR DESCRIPTION
Signed-off-by: Paul Saunders <paul.saunders@finbourne.com>

# Pull Request Checklist

- [x] Read the [contributing guidelines](../blob/master/docs/CONTRIBUTING.md)
- [x] Tests pass
- [x] Raised the PR against the `develop` branch

# Description of the PR

Fixes the tests to standardise on FBN_ACCESS_TOKEN for all sdks and FBN_BASE_API_URL for running the tests via the docker compose; again standardised across all sdks.