### PR TITLE
Feature/ctech 2527 Add config keys so ApiClient can be built by fbnsdkutilities

### DIFF
--- a/sdk/lusid/utilities/__init__.py
+++ b/sdk/lusid/utilities/__init__.py
@@ -5,3 +5,4 @@ from lusid.utilities.api_client_factory import ApiClientFactory
 from lusid.utilities.lusid_retry import lusidretry
 from lusid.utilities.proxy_config import ProxyConfig
 from lusid.utilities.api_configuration import ApiConfiguration
+from lusid.utilities.config_keys import ConfigKeys

--- a/sdk/lusid/utilities/config_keys.py
+++ b/sdk/lusid/utilities/config_keys.py
@@ -1,0 +1,13 @@
+from pathlib import Path
+import json
+
+
+class ConfigKeys:
+    config_key_path = "config_keys.json"
+
+    @classmethod
+    def get(cls):
+        with open(Path(__file__).parent.joinpath(cls.config_key_path)) as json_file:
+            config_keys = json.load(json_file)
+
+        return config_keys


### PR DESCRIPTION
# Pull Request Checklist

- [x] Read the [contributing guidelines](../blob/master/docs/CONTRIBUTING.md)
- [x] Tests pass
- [x] Raised the PR against the `develop` branch

# Description of the PR

Add config_keys so ApiClient can be built by fbnsdkutilities